### PR TITLE
Validate ZFS permissions before script execution

### DIFF
--- a/zfs-clear.sh
+++ b/zfs-clear.sh
@@ -92,7 +92,7 @@ function check_zfs_permissions {
 
   for perm in ${required}; do
     if ! grep -q "${perm}" <<< "${permissions}"; then
-      log err "User ${user} does not have 'zfs ${perm}' permission on '${dataset}'."
+      echo -e "${COLORS[ERROR]}Error: User ${user} does not have 'zfs ${perm}' permission on '${dataset}'.${NC}"
       return 1
     fi
   done
@@ -186,7 +186,7 @@ for snapshot in "${removals[@]}"; do
 
   dataset="${snapshot%@*}"
   if ! check_zfs_permissions "${dataset}" "destroy"; then
-    log warn "Skipped '${snapshot}': permission denied."
+    echo -e "${COLORS[WARN]}Warning: Skipped '${snapshot}': permission denied${NC}\n"
     continue
   fi
 

--- a/zfs-snap.sh
+++ b/zfs-snap.sh
@@ -53,9 +53,9 @@ function print_usage {
 function log {
   local level=$1; shift
   case $level in
-    (err*) logger -t "zfs-snap" -p "user.err" "$*"; echo -e "${COLORS[ERROR]}Error: $*${NC}" 2>&2 ;;
-    (war*) logger -t "zfs-snap" -p "user.warning" "$*"; echo -e "${COLORS[WARN]}Warning: $*${NC}" 1>&2 ;;
-    (inf*) logger -t "zfs-snap" -p "user.info" "$*"; echo -e "${COLORS[INFO]}$*${NC}" ;;
+    (err*) logger -t "zfs-snap" -p "user.err" "$*"; echo -e "${COLORS[ERROR]}Error:${NC} $*" 2>&2 ;;
+    (war*) logger -t "zfs-snap" -p "user.warning" "$*"; echo -e "${COLORS[WARN]}Warning:${NC} $*" 1>&2 ;;
+    (inf*) logger -t "zfs-snap" -p "user.info" "$*"; echo -e "${COLORS[INFO]}${NC}$*" ;;
   esac
 }
 
@@ -77,7 +77,7 @@ function create_snapshot {
   if ${ZFS} snap "${dataset}@${label}" > >(capture_errors) 2>&1; then
     log info "Created: '${dataset}@${label}'."
   else
-    log err "Failed to create snapshot '${label}' for dataset '${dataset}'."
+    log err "Failed: '${dataset}@${label}'."
     return 1
   fi
 }

--- a/zfs-to-zfs.sh
+++ b/zfs-to-zfs.sh
@@ -199,12 +199,12 @@ ${ZFS} list -o name,"${META_REPLICATION_TARGET}" -H -r \
   log info "Replicate '${source}' to '${target}'."
 
   if ! check_zfs_permissions "${source}" "send"; then
-    log warn "Skipped '${source}': no access to '${source}' ZFS dataset."
+    log warn "Skipped '${source}': permission denied for '${source}'."
     continue
   fi
 
   if ! check_zfs_permissions "${target}" "recv"; then
-    log warn "Skipped '${source}': no access to '${target}' ZFS dataset."
+    log warn "Skipped '${source}': permission denied for '${target}'."
     continue
   fi
 

--- a/zfs-to-zfs.sh
+++ b/zfs-to-zfs.sh
@@ -156,6 +156,31 @@ function bytes_to_human {
   echo "${bytes}${decimal_part} ${suffixes[${suffix_index}]}"
 }
 
+function check_zfs_permissions {
+  local dataset=$1
+  local required=$2
+  local user permissions original_ifs
+
+  user=$(whoami)
+  if [[ "${user}" == "root" ]]; then
+    return 0
+  fi
+
+  permissions=$( ${ZFS} allow "${dataset}" | grep -E "(${user}|@)")
+
+  # Temporary use comma as the delimiter
+  original_ifs=$IFS
+  IFS=','
+  trap 'IFS=$original_ifs' RETURN
+
+  for perm in ${required}; do
+    if ! grep -q "${perm}" <<< "${permissions}"; then
+      log err "User ${user} does not have 'zfs ${perm}' permission on '${dataset}'."
+      return 1
+    fi
+  done
+}
+
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
     --help) print_usage; exit 0 ;;
@@ -171,7 +196,17 @@ fi
 ${ZFS} list -o name,"${META_REPLICATION_TARGET}" -H -r \
     | awk -F '\t' '$2 != "-" && $1 != $2' \
     | while IFS=$'\t' read -r source target; do
-  log info "Initiating '${source}' to '${target}' replication."
+  log info "Replicate '${source}' to '${target}'."
+
+  if ! check_zfs_permissions "${source}" "send"; then
+    log warn "Skipped '${source}': no access to '${source}' ZFS dataset."
+    continue
+  fi
+
+  if ! check_zfs_permissions "${target}" "recv"; then
+    log warn "Skipped '${source}': no access to '${target}' ZFS dataset."
+    continue
+  fi
 
   if replicate_dataset "${source}" "${target}"; then
     log info "Replicated: '${source}'."


### PR DESCRIPTION
### Description

This update ensures that users have the correct ZFS access permissions before executing specific scripts. Each script requires specific ZFS permissions for its operations, as outlined in the table below:

| Script | Required ZFS Permissions |
| --- | --- |
| `zfs-snap` | `snap` |
| `zfs-clear` | `destroy` |
| `zfs-to-zfs` | `send`, `recv` |
| `zfs-to-s3` | `send` |

### Key Changes

- Added logic to check if the user has the required ZFS permissions for each script.
- Improved error handling to log missing permissions and exit early when insufficient access is detected.
- Ensured compatibility with non-root users, aligning with ZFS access delegation.
